### PR TITLE
Segfault case bug

### DIFF
--- a/src/PathPlanning.cpp
+++ b/src/PathPlanning.cpp
@@ -1573,7 +1573,8 @@ void PathPlanning::gradientNode(localNode* nodeTarget, double& dnx, double& dny)
     double dx, dy;
 
       if (((nodeTarget->nb4List[1] == NULL)&&(nodeTarget->nb4List[2] == NULL))||
-          ((nodeTarget->nb4List[1]->total_cost == INF)&&(nodeTarget->nb4List[2]->total_cost == INF)))
+          ((nodeTarget->nb4List[1] != NULL)&&(nodeTarget->nb4List[2] != NULL)&&
+           (nodeTarget->nb4List[1]->total_cost == INF)&&(nodeTarget->nb4List[2]->total_cost == INF)))
           dx = 0;
       else
       {
@@ -1589,7 +1590,8 @@ void PathPlanning::gradientNode(localNode* nodeTarget, double& dnx, double& dny)
           }
       }
       if (((nodeTarget->nb4List[0] == NULL)&&(nodeTarget->nb4List[3] == NULL))||
-          ((nodeTarget->nb4List[0]->total_cost == INF)&&(nodeTarget->nb4List[3]->total_cost == INF)))
+          ((nodeTarget->nb4List[0] != NULL)&&(nodeTarget->nb4List[3] != NULL)&&
+           (nodeTarget->nb4List[0]->total_cost == INF)&&(nodeTarget->nb4List[3]->total_cost == INF)))
           dy = 0;
       else
       {
@@ -1613,7 +1615,8 @@ void PathPlanning::gradientNode(globalNode* nodeTarget, double& dnx, double& dny
     double dx, dy;
 
       if (((nodeTarget->nb4List[1] == NULL)&&(nodeTarget->nb4List[2] == NULL))||
-          ((nodeTarget->nb4List[1]->total_cost == INF)&&(nodeTarget->nb4List[2]->total_cost == INF)))
+          ((nodeTarget->nb4List[1] != NULL)&&(nodeTarget->nb4List[2] != NULL)&&
+           (nodeTarget->nb4List[1]->total_cost == INF)&&(nodeTarget->nb4List[2]->total_cost == INF)))
           dx = 0;
       else
       {
@@ -1629,7 +1632,8 @@ void PathPlanning::gradientNode(globalNode* nodeTarget, double& dnx, double& dny
           }
       }
       if (((nodeTarget->nb4List[0] == NULL)&&(nodeTarget->nb4List[3] == NULL))||
-          ((nodeTarget->nb4List[0]->total_cost == INF)&&(nodeTarget->nb4List[3]->total_cost == INF)))
+          ((nodeTarget->nb4List[0] != NULL)&&(nodeTarget->nb4List[3] != NULL)&&
+           (nodeTarget->nb4List[0]->total_cost == INF)&&(nodeTarget->nb4List[3]->total_cost == INF)))
           dy = 0;
       else
       {


### PR DESCRIPTION
When just one of the nodeTarget->nb4List evaluated in the condition is NULL it does not trigger the first condition and tries to evaluate both of them. As one is NULL, a SEGFAULT exception is triggered. This commit tries to fix this case.